### PR TITLE
[GSW-425] chore: execute gnoland by shell due to use chainid environm…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY        --from=build /opt/build/gno.land/genesis /opt/gno/src/gno.land/genes
 COPY        --from=build /opt/build/examples /opt/gno/src/examples
 COPY        --from=build /opt/build/gnovm/stdlibs /opt/gno/src/gnovm/stdlibs
 COPY        --from=build /opt/build/gnovm/pkg /opt/gno/src/gnovm/pkg
+COPY        --from=build /opt/gno/src/start_gno.sh /opt/gno/bin/
 EXPOSE      26657
 CMD         ["gnoland", "start"]
 

--- a/start_gno.sh
+++ b/start_gno.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -z "$CHAINID" ]; then
+  echo "gnoland start"
+else
+  echo "gnoland start -chainid $CHAINID"
+fi

--- a/start_gno.sh
+++ b/start_gno.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$CHAINID" ]; then
-  echo "gnoland start"
+  gnoland start
 else
-  echo "gnoland start -chainid $CHAINID"
+  gnoland start -chainid $CHAINID
 fi


### PR DESCRIPTION
gnoland cli can be execute with chainid.

like
```
gnoland start -chainid $CHAINID
```